### PR TITLE
RHH-006 Fix issue with Kel'Thuzad interrupters

### DIFF
--- a/bot/src/classic-wow/raids/naxxramas/kel-thuzad/kel-thuzad.ts
+++ b/bot/src/classic-wow/raids/naxxramas/kel-thuzad/kel-thuzad.ts
@@ -223,7 +223,7 @@ export function makeAssignments(
     groupC: getInterrupters(meleeAssignments[2].assignments[0].characters),
   };
   for (const value of Object.values(interrupts)) {
-    if (value.length <= 1) {
+    if (value.length <= 1 && mageInterrupters.length !== 0) {
       const [mageToAdd] = mageInterrupters.splice(0, 1);
       value.push(mageToAdd);
     }

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -20,7 +20,7 @@ async function main() {
   const database = new Database();
   await refreshDatabase(database);
 
-  const raidEvent = await fetchEvent("1350951772964782120");
+  const raidEvent = await fetchEvent("1353489743962443869");
   if (!raidEvent) {
     return;
   }


### PR DESCRIPTION
# RHH-006 Fix issue with Kel'Thuzad interrupters
- Do not add mage interrupters if no mages are available.